### PR TITLE
add header Authorization verifying with caddy

### DIFF
--- a/prebuilt/context7-mcp/README.md
+++ b/prebuilt/context7-mcp/README.md
@@ -1,3 +1,7 @@
 # Context7 MCP
 
 The Context7 MCP server deployed on Phala Cloud to help agent retrieves up-to-date documentation and code examples for any library.
+
+**Notice**
+
+Please make sure the `BEARER_TOKEN` is set in the environment variable, which is used to authenticate the request to the server.

--- a/prebuilt/context7-mcp/docker-compose.yml
+++ b/prebuilt/context7-mcp/docker-compose.yml
@@ -1,9 +1,48 @@
 services:
-  context7-mcp-server:
+  app:
     image: tolak/context7-mcp-server:v0.1.1
-    ports:
-      - "3000:3000"
+    # ports: # Using caddy to proxy the server to enhance security, so no need to expose the port
+    #   - "3000:3000"
     environment:
       - PORT=3000
       - NODE_ENV=production
     restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    depends_on:
+      - app
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header Authorization "Bearer $BEARER_TOKEN"
+          }
+          route @valid_auth {
+              reverse_proxy app:3000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/prebuilt/demap-defilama/README.md
+++ b/prebuilt/demap-defilama/README.md
@@ -1,3 +1,7 @@
 # DeMCP Defilama
 
 A DeFiLlama MCP server deployed on Phala Cloud that enables AI agents to fetch real-time DeFi data, including protocol TVL (Total Value Locked), chain metrics, and token prices.
+
+**Notice**
+
+Please make sure the `BEARER_TOKEN` is set in the environment variable, which is used to authenticate the request to the server.

--- a/prebuilt/demap-defilama/docker-compose.yml
+++ b/prebuilt/demap-defilama/docker-compose.yml
@@ -1,6 +1,45 @@
 services:
-  defillama:
+  app:
     image: smartalbert/demcp-defillama-mcp-1
-    ports:
-      - 8080:8080
+    # ports: # Using caddy to proxy the server to enhance security, so no need to expose the port
+    #   - 8080:8080
     restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    depends_on:
+      - app
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header Authorization "Bearer $BEARER_TOKEN"
+          }
+          route @valid_auth {
+              reverse_proxy app:8080
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/prebuilt/elevenlabs-mcp-server/README.md
+++ b/prebuilt/elevenlabs-mcp-server/README.md
@@ -1,0 +1,5 @@
+# ElevenLabs MCP Server
+
+**Notice**
+
+Please make sure the `BEARER_TOKEN` is set in the environment variable, which is used to authenticate the request to the server.

--- a/prebuilt/elevenlabs-mcp-server/docker-compose.yaml
+++ b/prebuilt/elevenlabs-mcp-server/docker-compose.yaml
@@ -1,13 +1,15 @@
 services:
-  elevenlabs-mcp:
+  app:
     image: tolak/elevenlabs-mcp-server:v0.1.0
-    ports:
-      - "8000:8000"
+    # ports: # Using caddy to proxy the server to enhance security, so no need to expose the port
+    #   - "8000:8000"
     volumes:
       - /root/data:/root/Desktop
     environment:
       - ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY}
       - ELEVENLABS_MCP_BASE_PATH=${ELEVENLABS_MCP_BASE_PATH}
+    networks:
+      - internal
 
   fileserver:
     image: python:3.11-slim
@@ -17,3 +19,42 @@ services:
       - /root/data:/root/data
     working_dir: /root/data
     command: python -m http.server 8080
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    depends_on:
+      - app
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header Authorization "Bearer $BEARER_TOKEN"
+          }
+          route @valid_auth {
+              reverse_proxy app:8080
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/prebuilt/evm-mcp-server/docker-compose.yml
+++ b/prebuilt/evm-mcp-server/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
-  evm-mcp:
+  app:
     image: tolak/evm-mcp-server:v0.1.0
-    ports:
-      - "3000:3000"
+    # ports: # Using caddy to proxy the server to enhance security, so no need to expose the port
+    #   - "3000:3000"
     environment:
       - PORT=3000
       - EVM_PRIVATE_KEY=${EVM_PRIVATE_KEY}
@@ -11,3 +11,42 @@ services:
       - PERPLEXITY_API_KEY=${PERPLEXITY_API_KEY}
       - COINGECKO_PRO_API_KEY=${COINGECKO_PRO_API_KEY}
     restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    depends_on:
+      - app
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header Authorization "Bearer $BEARER_TOKEN"
+          }
+          route @valid_auth {
+              reverse_proxy app:3000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/prebuilt/evm-mcp-server/tee.md
+++ b/prebuilt/evm-mcp-server/tee.md
@@ -1,0 +1,60 @@
+## Step1: Remove `build` from docker compose file since it doesn't support build from source
+
+```
+build:
+    context: .
+    dockerfile: Dockerfile
+```
+
+Instead, use `image` like below:
+
+```
+services:
+  evm-mcp:
+    image: tolak/evm-mcp-server:v0.1.0
+    ports:
+      - "3000:3000"
+```
+
+## Step2: Build docker image and push to docker hub
+
+Build docker image with `x86_64` arch and change `image` in docker compose file to image name on docker hub with exact tag name
+
+```
+docker build --platform linux/amd64 -t <user>/evm-mcp-server .
+docker tag <user>/evm-mcp-server <user>/evm-mcp-server:v0.1.0
+docker push <user>/evm-mcp-server:v0.1.0
+```
+
+## Step3: Deploy with docker-compose.yml
+
+You can use the docker-compose file on Phala Cloud to deploy. Head to [Phala Cloud Doc](https://docs.phala.network/phala-cloud/getting-started) for more details.
+
+### Set environments
+
+Make sure your set the following two environments on the dashboard **Encrypted Secrets** section.
+
+- EVM_PRIVATE_KEY
+- RPC_URL
+
+Below are optional environments.
+
+- OPENAI_API_KEY=
+- PERPLEXITY_API_KEY=
+- COINGECKO_PRO_API_KEY=
+
+After finished deployment, you will see a public endpoint at **Network** tab on the dashboard, which you can use to access the MCP server.
+
+## Step4: Config MCP client
+
+Config MCP client like Claude Desktop, set MCP server using `sse` transport with the public endpoint get from Phala Cloud. For example: `https://80a95d038daac93fb069730cf2465d7ed9e25b1d-3000.dstack-prod5.phala.network/sse`:
+
+```
+"EVM MCP": {
+  "url": "https://80a95d038daac93fb069730cf2465d7ed9e25b1d-3000.dstack-prod5.phala.network/sse"
+}
+```
+
+**Notice**
+
+Please make sure the `BEARER_TOKEN` is set in the environment variable, which is used to authenticate the request to the server.

--- a/prebuilt/figma-mcp/README.md
+++ b/prebuilt/figma-mcp/README.md
@@ -1,3 +1,7 @@
 # Figma MCP
 
 Give Cursor, Windsurf, Cline, and other AI-powered coding tools access to your Figma files with this Model Context Protocol server.
+
+**Notice**
+
+Please make sure the `BEARER_TOKEN` is set in the environment variable, which is used to authenticate the request to the server.

--- a/prebuilt/figma-mcp/docker-compose.yaml
+++ b/prebuilt/figma-mcp/docker-compose.yaml
@@ -1,8 +1,8 @@
 services:
-  figma-mcp:
+  app:
     image: tolak/figma-context-mcp:v0.1.1
-    ports:
-      - "3333:3333"
+    # ports: # Using caddy to proxy the server to enhance security, so no need to expose the port
+    #   - "3333:3333"
     environment:
       - NODE_ENV=production
       # You'll need to provide your Figma API key through environment variables
@@ -10,3 +10,42 @@ services:
     volumes:
       - /var/run/tappd.sock:/var/run/tappd.sock
     restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    depends_on:
+      - app
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header Authorization "Bearer $BEARER_TOKEN"
+          }
+          route @valid_auth {
+              reverse_proxy app:3333
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/prebuilt/near-mcp-server/README.md
+++ b/prebuilt/near-mcp-server/README.md
@@ -2,3 +2,6 @@
 
 This tool provides a way for LLMs and AI agents to securely access and interact with NEAR accounts and blockchain functionality.
 
+**Notice**
+
+Please make sure the `BEARER_TOKEN` is set in the environment variable, which is used to authenticate the request to the server.

--- a/prebuilt/near-mcp-server/docker-compose.yml
+++ b/prebuilt/near-mcp-server/docker-compose.yml
@@ -1,13 +1,12 @@
 services:
-  near-mcp:
+  app:
     image: tolak/near-mcp-server:v0.1.0
     container_name: near-mcp-server
     restart: unless-stopped
     volumes:
       - ~/.near-keystore:/root/.near-keystore
-    ports:
-      # Expose the SSE server port
-      - "3001:3001"
+    # ports: # Using caddy to proxy the server to enhance security, so no need to expose the port
+    #   - "3001:3001"
     # Override the entrypoint from the Dockerfile
     entrypoint: []
     command: ["sh", "-c", "mkdir -p /root/.near-keystore/$${NEAR_NETWORK} && if [ ! -z \"$${NEAR_KEYSTOREDATA}\" ] && [ ! -z \"$${NEAR_NETWORK}\" ] && [ ! -z \"$${NEAR_ACCOUNT_ID}\" ]; then echo \"$${NEAR_KEYSTOREDATA}\" | base64 -d > /root/.near-keystore/$${NEAR_NETWORK}/$${NEAR_ACCOUNT_ID}.json && echo \"Keystore data written to /root/.near-keystore/$${NEAR_NETWORK}/$${NEAR_ACCOUNT_ID}.json\"; fi && cd /app && exec node dist/near-mcp.js run --remote --port 3001"]
@@ -17,3 +16,42 @@ services:
       - NEAR_NETWORK=${NEAR_NETWORK:-mainnet}
       - NEAR_ACCOUNT_ID=${NEAR_ACCOUNT_ID}
       - NEAR_KEYSTORE=/root/.near-keystore
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    depends_on:
+      - app
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header Authorization "Bearer $BEARER_TOKEN"
+          }
+          route @valid_auth {
+              reverse_proxy app:3001
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/prebuilt/solana-mcp/README.md
+++ b/prebuilt/solana-mcp/README.md
@@ -1,1 +1,5 @@
 # Solana MCP by SendAI & DARK
+
+**Notice**
+
+Please make sure the `BEARER_TOKEN` is set in the environment variable, which is used to authenticate the request to the server.

--- a/prebuilt/solana-mcp/docker-compose.yml
+++ b/prebuilt/solana-mcp/docker-compose.yml
@@ -1,12 +1,51 @@
 services:
-  solana-mcp:
+  app:
     image: tolak/solana-mcp-server:v0.1.0
     container_name: solana-mcp
-    ports:
-      - "3000:3000"
+    # ports: # Using caddy to proxy the server to enhance security, so no need to expose the port
+    #   - "3000:3000"
     environment:
       - SOLANA_PRIVATE_KEY=${SOLANA_PRIVATE_KEY}
       - RPC_URL=${RPC_URL}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - PORT=3000
     restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    depends_on:
+      - app
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header Authorization "Bearer $BEARER_TOKEN"
+          }
+          route @valid_auth {
+              reverse_proxy app:3000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/prebuilt/supabase-db/README.md
+++ b/prebuilt/supabase-db/README.md
@@ -1,3 +1,7 @@
 # Supabase MCP
 
 You can use this server to connect your favorite AI tools (such as Cursor or Claude) directly with Supabase.
+
+**Notice**
+
+Please make sure the `BEARER_TOKEN` is set in the environment variable, which is used to authenticate the request to the server.

--- a/prebuilt/supabase-db/docker-compose.yml
+++ b/prebuilt/supabase-db/docker-compose.yml
@@ -1,11 +1,50 @@
 services:
-  mcp-server:
+  app:
     image: tolak/supabase-mcp-server:v0.1.5
-    ports:
-      - "3000:3000"
+    # ports: # Using caddy to proxy the server to enhance security, so no need to expose the port
+    #   - "3000:3000"
     environment:
       - NODE_ENV=production
       - SUPABASE_ACCESS_TOKEN=${SUPABASE_ACCESS_TOKEN}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    depends_on:
+      - app
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header Authorization "Bearer $BEARER_TOKEN"
+          }
+          route @valid_auth {
+              reverse_proxy app:3000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge


### PR DESCRIPTION
## Description
Add header Authorization verifying with caddy to the prebuilt mcp servers.

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My changes follow the project's style guidelines
