### PR TITLE
Add Maybe Finance template for Phala Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ A curated list of awesome Phala Cloud resources, tools, and templates.
 
 ### Other Templates
 
+- [**n8n Workflow Automation**](https://github.com/Phala-Network/awesome-phala-cloud/tree/main/templates/n8n) - A powerful workflow automation tool deployed on Phala Cloud with OAuth2 authentication fixes for TEE environment. Build complex automations, integrate with 400+ services, and run workflows securely within the TEE. *by n8n*
+- [**Maybe Finance**](https://github.com/Phala-Network/awesome-phala-cloud/tree/main/templates/maybe-ai) - A comprehensive open-source personal finance management app deployed on Phala Cloud. Track expenses, budgets, investments, and net worth with bank syncing, AI insights, and beautiful analytics - all secured within TEE infrastructure. *by Maybe Finance*
 - [**Anyone Anon Service**](https://github.com/rA3ka/dstack-examples/tree/main/anyone-anon-service) - Sets up a Anyone Anon (hidden) service and serves an nginx website from that. *by Anyone*
 - [**Anyone Network Relay**](https://github.com/rA3ka/anon-relay-docker/tree/main) - Set up a Anon relay and participate in expanding the Anyone Network by providing bandwidth to earn recognition rewards. *by Anyone*
 - [**TEE Tor Hidden Service**](https://github.com/Dstack-TEE/dstack-examples/tree/main/tor-hidden-service) - This docker compose example sets up a Tor hidden service and serves an nginx website from that. *by Dstack-TEE*

--- a/templates/maybe-ai/.env.example
+++ b/templates/maybe-ai/.env.example
@@ -1,0 +1,14 @@
+# Maybe Finance Environment Configuration
+
+# REQUIRED: Security key for Rails sessions
+# Generate with: openssl rand -hex 64
+SECRET_KEY_BASE=your_secret_key_base_here
+
+# REQUIRED: PostgreSQL password
+# Choose a strong password for your database
+POSTGRES_PASSWORD=your_postgres_password_here
+
+# OPTIONAL: OpenAI API Key
+# Only needed if you want to use AI features (chat, smart rules)
+# Get your key from: https://platform.openai.com/api-keys
+# OPENAI_ACCESS_TOKEN=sk-your-openai-api-key-here

--- a/templates/maybe-ai/README.md
+++ b/templates/maybe-ai/README.md
@@ -1,0 +1,167 @@
+# Maybe Finance on Phala Cloud
+
+Deploy [Maybe Finance](https://github.com/maybe-finance/maybe), an open-source personal finance management app, on Phala Cloud's TEE infrastructure.
+
+## Features
+
+- 💰 **Complete Financial Management**: Track expenses, budgets, investments, and net worth
+- 🏦 **Bank Syncing**: Connect bank accounts via Plaid (requires API key)
+- 📊 **Beautiful Analytics**: Visualize spending patterns and financial trends
+- 🤖 **AI Assistant**: Smart financial insights and rule suggestions (requires OpenAI key)
+- 🔒 **Privacy-First**: Self-hosted in TEE for maximum security
+- 📱 **Modern UI**: Clean, responsive interface built with Rails & Hotwire
+
+## Quick Start
+
+### 1. Set Up Environment
+
+Create a `.env` file with required configuration:
+
+```bash
+# Generate a secret key
+openssl rand -hex 64
+
+# Add to .env file:
+SECRET_KEY_BASE=<your-generated-key>
+POSTGRES_PASSWORD=<choose-a-strong-password>
+
+# Optional: Add OpenAI key for AI features
+# OPENAI_ACCESS_TOKEN=sk-your-openai-api-key
+```
+
+### 2. Deploy to Phala Cloud
+
+```bash
+# Deploy the application
+phala cvms create -c docker-compose.yml -e .env --name maybe-finance
+
+# Check deployment status
+phala cvms list
+```
+
+### 3. Access Your App
+
+After deployment completes:
+1. Visit: `https://<your-app-id>-3000.teehouse.phatfn.xyz`
+2. Create your account
+3. Start managing your finances!
+
+## Configuration
+
+### Required Environment Variables
+
+- `SECRET_KEY_BASE`: Rails session encryption key (generate with `openssl rand -hex 64`)
+- `POSTGRES_PASSWORD`: Database password
+
+### Optional Features
+
+- **AI Assistant**: Set `OPENAI_ACCESS_TOKEN` to enable smart insights
+- **Bank Connections**: Configure Plaid credentials (see Maybe docs)
+- **Email Notifications**: Configure SMTP settings
+
+## Deployment Journey & Solutions
+
+### Challenge: Rails CSRF Protection in TEE
+
+**Issue**: Users couldn't create accounts - got "The change you wanted was rejected" (422 error)
+
+**Root Cause**: Rails was generating HTTP URLs while Phala Cloud serves over HTTPS, causing CSRF token validation failures
+
+**Solution**: Configure Rails to understand it's behind an HTTPS proxy:
+```yaml
+RAILS_FORCE_SSL: "false"  # Don't enforce SSL (TEE handles it)
+RAILS_ASSUME_SSL: "true"   # But assume we're on HTTPS
+```
+
+### Challenge: Host Authorization
+
+**Issue**: Rails rejected requests from Phala Cloud domains
+
+**Solution**: Clear host restrictions and use DSTACK variables:
+```yaml
+APP_DOMAIN: "${DSTACK_APP_ID}-3000.${DSTACK_GATEWAY_DOMAIN}"
+# Plus: Rails.application.config.hosts.clear in entrypoint
+```
+
+### Challenge: Invite Code Requirement
+
+**Issue**: Default self-hosted mode requires invite codes
+
+**Solution**: Disable requirement on first run:
+```bash
+Setting.require_invite_for_signup = false
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────┐
+│         Phala Cloud TEE             │
+├─────────────────────────────────────┤
+│  ┌─────────┐  ┌─────────┐          │
+│  │  Rails  │  │ Sidekiq │          │
+│  │  (3000) │  │ Worker  │          │
+│  └────┬────┘  └────┬────┘          │
+│       │            │                │
+│  ┌────┴────────────┴────┐          │
+│  │    PostgreSQL 16     │          │
+│  └──────────────────────┘          │
+│  ┌──────────────────────┐          │
+│  │      Redis 7         │          │
+│  └──────────────────────┘          │
+└─────────────────────────────────────┘
+```
+
+## Advanced Configuration
+
+### Enable AI Features
+
+```bash
+# Add to .env
+OPENAI_ACCESS_TOKEN=sk-your-openai-api-key
+
+# Upgrade deployment
+phala cvms upgrade <app-id> -c docker-compose.yml -e .env
+```
+
+### Connect Bank Accounts
+
+See [Maybe's Plaid documentation](https://github.com/maybe-finance/maybe/wiki) for bank syncing setup.
+
+## Troubleshooting
+
+### Registration Issues
+
+If you see "The change you wanted was rejected":
+1. Check deployment logs for errors
+2. Ensure `RAILS_ASSUME_SSL: "true"` is set
+3. Verify password meets requirements:
+   - Minimum 8 characters
+   - Upper and lowercase letters
+   - At least one number
+   - At least one special character
+
+### Database Connection
+
+If the app won't start:
+1. Check if PostgreSQL is healthy: `phala cvms get <app-id>`
+2. Ensure `POSTGRES_PASSWORD` matches in all services
+3. Wait a few minutes for initial database setup
+
+## Security Considerations
+
+- All data is encrypted within the TEE
+- Passwords are hashed using bcrypt
+- Session cookies are encrypted with `SECRET_KEY_BASE`
+- Bank credentials (if used) are stored encrypted
+- No data leaves the TEE without your explicit action
+
+## Resources
+
+- [Maybe Finance GitHub](https://github.com/maybe-finance/maybe)
+- [Maybe Documentation](https://github.com/maybe-finance/maybe/wiki)
+- [Phala Cloud Dashboard](https://cloud.phala.network/dashboard/)
+
+## License
+
+Maybe Finance is open source under the AGPL-3.0 license. This template is provided as-is for deployment on Phala Cloud.

--- a/templates/maybe-ai/docker-compose.yml
+++ b/templates/maybe-ai/docker-compose.yml
@@ -6,6 +6,10 @@ x-rails-env: &rails_env
   # Critical: Tell Rails it's behind HTTPS proxy
   RAILS_FORCE_SSL: "false"
   RAILS_ASSUME_SSL: "true"
+  # Force HTTPS in URLs 
+  FORCE_SSL: "false"
+  X_FORWARDED_SSL: "on"
+  X_FORWARDED_PROTO: "https"
   POSTGRES_USER: maybe_user
   POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
   POSTGRES_DB: maybe_production
@@ -17,8 +21,8 @@ x-rails-env: &rails_env
   # Use DSTACK variables for proper domain configuration
   APP_DOMAIN: "${DSTACK_APP_ID}-3000.${DSTACK_GATEWAY_DOMAIN}"
   RAILS_HOSTS: ".${DSTACK_GATEWAY_DOMAIN},.teehouse.phatfn.xyz,localhost"
-  # Optional: OpenAI for AI features
-  OPENAI_ACCESS_TOKEN: ${OPENAI_ACCESS_TOKEN}
+  # Optional: OpenAI for AI features (leave empty to skip)
+  OPENAI_ACCESS_TOKEN: ${OPENAI_ACCESS_TOKEN:-}
 
 services:
   db:

--- a/templates/maybe-ai/docker-compose.yml
+++ b/templates/maybe-ai/docker-compose.yml
@@ -1,0 +1,109 @@
+version: '3.8'
+
+x-rails-env: &rails_env
+  SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+  SELF_HOSTED: "true"
+  # Critical: Tell Rails it's behind HTTPS proxy
+  RAILS_FORCE_SSL: "false"
+  RAILS_ASSUME_SSL: "true"
+  POSTGRES_USER: maybe_user
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+  POSTGRES_DB: maybe_production
+  DB_HOST: db
+  DB_PORT: 5432
+  REDIS_URL: redis://redis:6379/1
+  RAILS_ENV: production
+  RAILS_LOG_TO_STDOUT: "true"
+  # Use DSTACK variables for proper domain configuration
+  APP_DOMAIN: "${DSTACK_APP_ID}-3000.${DSTACK_GATEWAY_DOMAIN}"
+  RAILS_HOSTS: ".${DSTACK_GATEWAY_DOMAIN},.teehouse.phatfn.xyz,localhost"
+  # Optional: OpenAI for AI features
+  OPENAI_ACCESS_TOKEN: ${OPENAI_ACCESS_TOKEN}
+
+services:
+  db:
+    image: postgres:16-alpine
+    platform: linux/amd64
+    volumes:
+      - /var/run/tappd.sock:/var/run/tappd.sock
+      - postgres-data:/var/lib/postgresql/data
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: maybe_user
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: maybe_production
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U maybe_user -d maybe_production"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    platform: linux/amd64
+    volumes:
+      - /var/run/tappd.sock:/var/run/tappd.sock
+      - redis-data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  web:
+    image: ghcr.io/maybe-finance/maybe:latest
+    platform: linux/amd64
+    ports:
+      - "3000:3000"
+    volumes:
+      - /var/run/tappd.sock:/var/run/tappd.sock
+      - app-storage:/rails/storage
+    restart: unless-stopped
+    environment:
+      <<: *rails_env
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    # Fix HTTPS redirect issue for TEE environment
+    entrypoint: >
+      sh -c "
+        echo 'Starting Maybe Finance...' &&
+        echo 'Waiting for database...' &&
+        until pg_isready -h db -U maybe_user; do
+          echo 'Database is not ready, waiting...';
+          sleep 2;
+        done;
+        echo 'Database is ready!' &&
+        ./bin/rails db:prepare &&
+        echo 'Configuring Rails for Phala Cloud TEE...' &&
+        echo 'Rails.application.config.hosts.clear' | ./bin/rails runner - &&
+        echo 'Rails.application.config.force_ssl = false' | ./bin/rails runner - &&
+        echo 'Rails.application.config.assume_ssl = true' | ./bin/rails runner - &&
+        echo 'Setting.require_invite_for_signup = false' | ./bin/rails runner - &&
+        echo 'Starting Rails server...' &&
+        ./bin/rails server -b 0.0.0.0
+      "
+
+  worker:
+    image: ghcr.io/maybe-finance/maybe:latest
+    platform: linux/amd64
+    volumes:
+      - /var/run/tappd.sock:/var/run/tappd.sock
+      - app-storage:/rails/storage
+    restart: unless-stopped
+    environment:
+      <<: *rails_env
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: bundle exec sidekiq
+
+volumes:
+  app-storage:
+  postgres-data:
+  redis-data:


### PR DESCRIPTION
## 🏦 Maybe Finance Template for Phala Cloud

This PR adds a comprehensive template for deploying [Maybe Finance](https://github.com/maybe-finance/maybe), an open-source personal finance management app, on Phala Cloud's TEE infrastructure.

### ✨ Features

- 💰 **Complete Financial Management**: Track expenses, budgets, investments, and net worth
- 🏦 **Bank Syncing**: Connect bank accounts via Plaid integration
- 📊 **Beautiful Analytics**: Visualize spending patterns and financial trends  
- 🤖 **AI Assistant**: Smart financial insights with OpenAI integration
- 🔒 **Privacy-First**: Self-hosted in TEE for maximum security
- 📱 **Modern UI**: Clean, responsive interface built with Rails & Hotwire

### 🔧 Technical Solutions

This template includes battle-tested solutions for deploying Rails applications in TEE environments:

#### 1. **Rails CSRF Protection Fix**
```yaml
RAILS_FORCE_SSL: "false"      # Don't enforce SSL (TEE handles it)
RAILS_ASSUME_SSL: "true"      # But assume we're on HTTPS
X_FORWARDED_SSL: "on"         # Tell Rails about SSL termination
X_FORWARDED_PROTO: "https"    # Specify HTTPS protocol
```

**Issue**: Rails was generating HTTP URLs while Phala serves HTTPS, causing CSRF token validation failures and 422 errors.

#### 2. **Host Authorization Fix**
```yaml
APP_DOMAIN: "${DSTACK_APP_ID}-3000.${DSTACK_GATEWAY_DOMAIN}"
RAILS_HOSTS: ".${DSTACK_GATEWAY_DOMAIN},.teehouse.phatfn.xyz,localhost"
# Plus: Rails.application.config.hosts.clear in entrypoint
```

**Issue**: Rails rejecting requests from Phala Cloud domains due to host validation.

#### 3. **TEE Environment Optimizations**
- Proper `platform: linux/amd64` specification
- TEE socket mounting: `/var/run/tappd.sock:/var/run/tappd.sock`
- Database health checks and proper startup sequencing
- Invite code requirement disabled: `Setting.require_invite_for_signup = false`

### 📁 Template Contents

```
templates/maybe-ai/
├── docker-compose.yml    # Production-ready deployment config with all fixes
├── .env.example         # Environment variables template  
├── README.md           # Complete documentation with deployment journey
└── ../icons/maybe-finance.png  # Template icon
```

### 🚀 Quick Deploy

```bash
# Generate security key
SECRET_KEY_BASE=$(openssl rand -hex 64)

# Set up environment
echo "SECRET_KEY_BASE=$SECRET_KEY_BASE" > .env
echo "POSTGRES_PASSWORD=your-strong-password" >> .env

# Optional: Add OpenAI for AI features
# echo "OPENAI_ACCESS_TOKEN=sk-your-key" >> .env

# Deploy to Phala Cloud  
phala cvms create -c docker-compose.yml -e .env --name maybe-finance
```

### 📖 Comprehensive Documentation

The README includes:
- **Quick Start Guide**: Step-by-step deployment instructions
- **Deployment Journey & Solutions**: Detailed technical solutions we discovered
- **Architecture Overview**: Visual representation of the Rails + PostgreSQL + Redis stack
- **Troubleshooting Guide**: Common issues and their fixes
- **Security Considerations**: TEE-specific security notes

### 🔍 Debugging Journey

This template is the result of extensive debugging to make Rails work properly in TEE:

1. **422 "Change was rejected" errors** → Fixed with proper HTTPS configuration
2. **CSRF token mismatches** → Solved with `RAILS_ASSUME_SSL: "true"`
3. **Host authorization failures** → Resolved with `DSTACK_*` variables
4. **Invite code requirements** → Disabled for first-time setup
5. **Database connection issues** → Added proper health checks

### 🔗 Also Updated

- Added Maybe Finance entry to main README under "Other Templates"
- Also added n8n template entry (we successfully deployed n8n previously)
- Both templates demonstrate modern web apps working securely in TEE

### 💡 Why This Matters

This template enables users to:
- Securely manage personal finances using TEE infrastructure
- Get all privacy/security benefits of confidential computing
- Deploy a production-ready Rails app without TEE-specific knowledge
- Learn from our debugging solutions for future Rails deployments

The template has been tested and verified working on Phala Cloud\! 🎉

🤖 Generated with [Claude Code](https://claude.ai/code)